### PR TITLE
#162191459 get specific redflag incident by id

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,14 +1,24 @@
 from flask import Flask
 from flask_restful import Api
 
-from app.api.v1.views import PostIncidents, GetIncidents
+from app.api.v1.views import PostIncidents, Incidents, Get_incident_by_id, Get_specific_incident
 
 
 def create_app():
 
     app = Flask(__name__)
-    user = Api(app)
-    user.add_resource(PostIncidents, "/api/v1/incident")
-    user.add_resource(GetIncidents, "/api/v1/incident")
+    api = Api(app)
+
+    """create incidents"""
+    api.add_resource(PostIncidents, "/api/v1/incident")
+
+    """get all incidents"""
+    api.add_resource(Incidents, "/api/v1/incident")
+
+    """get incident by id"""
+    api.add_resource(Get_incident_by_id, "/api/v1/incident/<int:id>")
+
+    """ user can get their specific incidents """
+    api.add_resource(Get_specific_incident, "/api/v1/incident/<int:id>")
 
     return app

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -1,12 +1,12 @@
 from datetime import datetime
-Incidents = []
+incidents = []
 
 
-class Incident():
+class Incident:
 
     incident_id = 1
 
-    def __init__(self, created_by, Type, location, status, image, video, comment):
+    def __init__(self, created_by=None, Type=None, location=None, status=None, image=None, video=None, comment=None):
 
         self.created_on = datetime.now().replace(second=0, microsecond=0)
         self.created_by = created_by  # represents the user who created this record
@@ -34,3 +34,8 @@ class Incident():
             video=self.video,
             comment=self.comment
         )
+
+    def get_incident_by_id(self, id):
+        for incident in incidents:
+            if incident.id == id:
+                return incident

--- a/app/api/v1/views.py
+++ b/app/api/v1/views.py
@@ -1,7 +1,7 @@
 # module import
 from flask_restful import Resource, reqparse
 
-from app.api.v1.models import Incident, Incidents
+from app.api.v1.models import Incident, incidents
 from utils.validators import Validate
 
 
@@ -39,13 +39,51 @@ class PostIncidents(Resource):
         incident = Incident(created_by, Type, location,
                             status, comment, image, video)
 
-        Incidents.append(incident)
+        print(f"{incident.Type}")
+
+        incidents.append(incident)
 
         return {"incident": "created successfully"}, 201
 
-        print(f"{incident.Type}")
 
+class Incidents(Resource):
 
-class GetIncidents(Resource):
     def get(self):
-        return {"Incidents": [Incident.serializer() for Incident in Incidents]}
+        return {"Incidents": [Incident.serializer() for Incident in incidents]}
+
+
+class Get_specific_incident(Resource):
+
+    parsing = reqparse.RequestParser()
+    parsing.add_argument("created_by", type=str,
+                         required=True, help="This field is required")
+    parsing.add_argument("Type", type=str, required=True,
+                         help="This field is required")
+    parsing.add_argument("location", type=str, required=True,
+                         help="This field is required")
+    parsing.add_argument("status", type=str, required=True,
+                         help="This field is required")
+    parsing.add_argument("image", type=str, required=True,
+                         help="This field is required")
+    parsing.add_argument("video", type=str, required=True,
+                         help="This field is required")
+    parsing.add_argument("comment", type=str, required=True,
+                         help="This field is required")
+
+    """ get specific incident """
+
+    def get(self, id):
+        incident = Incident().get_incident_by_id(id)
+        if not incident:
+            return {"Message": "incident does not exit"}, 404
+        else:
+            return {"Incident": incident.serializer()}, 200
+
+
+class Get_incident_by_id(Resource):
+    def get(self, id):
+        incident = Incident().get_incident_by_id(id)
+        if not incident:
+            return {"Message": "incident does not exit"}, 404
+        else:
+            return {"Incident": incident.serializer()}, 200


### PR DESCRIPTION
![screenshot from 2018-11-28 19-30-46](https://user-images.githubusercontent.com/6553892/49168089-d6657100-f347-11e8-8fdc-df45ac9ef44c.png)

**What does this PR do?**

It is for getting a specific red flag incident or get a single red flag by id.

**Description of Task to be completed**

I have created a get_incident_by_id method where a user/admin should be able to retrieve (GET) all incidents created or a single red flag by using the id.
It should display all the red flag details such as id, user's name, date of creation, type of incident, file uploads and the comments. 

**How should this be manually tested?**

clone the branch as below:
```
git clone -b ft-get-incident-by-id-162191459 git@github.com:markmumo/IReporter-API.git

````

**Relevant pivotal stories?**
[#162191459](https://www.pivotaltracker.com/story/show/162191459/comments/197022152)